### PR TITLE
Enable Gmail-style bank filter

### DIFF
--- a/bankfees/ui/src/components/search-interface.tsx
+++ b/bankfees/ui/src/components/search-interface.tsx
@@ -7,6 +7,7 @@ import { SearchResults } from "@/components/search-results";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useSearchResults } from "@/hooks/use-search-results";
+import { parseSearchInput } from "@/lib/utils";
 import { Search } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -42,6 +43,8 @@ export function SearchInterface() {
       performSearch(searchQuery);
     }
   };
+
+  const { query: highlightQuery } = parseSearchInput(searchQuery);
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-[1fr_1.5fr] gap-6">
@@ -81,6 +84,7 @@ export function SearchInterface() {
               results={results}
               onResultClick={setSelectedResult}
               searchQuery={searchQuery}
+              highlightQuery={highlightQuery}
             />
           )}
         </div>
@@ -94,7 +98,7 @@ export function SearchInterface() {
               "/api/file/"
             )}
             pageNumber={selectedResult.pageNumber}
-            searchTerm={searchQuery}
+            searchTerm={highlightQuery}
             highlight={selectedResult.highlight}
             bankName={selectedResult.bankName}
           />

--- a/bankfees/ui/src/components/search-results.tsx
+++ b/bankfees/ui/src/components/search-results.tsx
@@ -28,10 +28,17 @@ interface SearchResultsProps {
   updating?: boolean;
   results: BankGroup[];
   onResultClick: (result: SearchResult) => void;
-  searchQuery: string;
+  searchQuery: string; // original user input
+  highlightQuery: string; // parsed query used for highlighting
 }
 
-export function SearchResults({ updating, results, onResultClick, searchQuery }: SearchResultsProps) {
+export function SearchResults({
+  updating,
+  results,
+  onResultClick,
+  searchQuery,
+  highlightQuery,
+}: SearchResultsProps) {
   const [openBanks, setOpenBanks] = useState<string[]>([]);
   const [expandedResults, setExpandedResults] = useState<string[]>([]);
 
@@ -125,7 +132,7 @@ export function SearchResults({ updating, results, onResultClick, searchQuery }:
 
                             {/* Primary context snippet */}
                             <div className="text-sm mb-2">
-                              <HighlightedText text={result.highlight} searchTerm={searchQuery} />
+                              <HighlightedText text={result.highlight} searchTerm={highlightQuery} />
                             </div>
 
                             {/* Additional context snippets */}
@@ -137,7 +144,7 @@ export function SearchResults({ updating, results, onResultClick, searchQuery }:
                                         key={snippetIdx}
                                         className="text-sm text-slate-600 pl-4 border-l-2 border-slate-200"
                                       >
-                                        <HighlightedText text={snippet} searchTerm={searchQuery} />
+                                        <HighlightedText text={snippet} searchTerm={highlightQuery} />
                                       </div>
                                     ))
                                   : result.contextSnippets.length > 1 && (

--- a/bankfees/ui/src/hooks/use-search-results.ts
+++ b/bankfees/ui/src/hooks/use-search-results.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { searchMeiliSearch } from "@/lib/meilisearch";
+import { parseSearchInput } from "@/lib/utils";
 import { useState } from "react";
 
 interface SearchResult {
@@ -23,18 +24,20 @@ export function useSearchResults() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const performSearch = async (query: string) => {
+  const performSearch = async (input: string) => {
     setIsLoading(true);
     setError(null);
 
-    if (query.trim() === "") {
+    const { query, filters } = parseSearchInput(input);
+
+    if (query.trim() === "" && filters.length === 0) {
       setResults([]);
       setIsLoading(false);
       return;
     }
 
     try {
-      const searchResults = await searchMeiliSearch(query);
+      const searchResults = await searchMeiliSearch(query, filters);
 
       // Group results by bank
       const groupedByBank: Record<string, SearchResult[]> = {};

--- a/bankfees/ui/src/lib/meilisearch.ts
+++ b/bankfees/ui/src/lib/meilisearch.ts
@@ -33,7 +33,10 @@ interface Document {
 
 const CONTEXT_LENGTH = 200;
 
-export async function searchMeiliSearch(query: string): Promise<SearchHit[]> {
+export async function searchMeiliSearch(
+  query: string,
+  filters: string[] = []
+): Promise<SearchHit[]> {
   try {
     const searchResults = await index.search(query, {
       limit: 100,
@@ -43,6 +46,7 @@ export async function searchMeiliSearch(query: string): Promise<SearchHit[]> {
       attributesToCrop: ["content"],
       cropLength: 150,
       cropMarker: "...",
+      filter: filters.length > 0 ? filters.join(" AND ") : undefined,
     });
 
     // Process the results to extract highlights and other information

--- a/bankfees/ui/src/lib/utils.ts
+++ b/bankfees/ui/src/lib/utils.ts
@@ -4,3 +4,28 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export interface ParsedSearch {
+  query: string
+  filters: string[]
+}
+
+/**
+ * Parse a user provided search string supporting gmail style operators.
+ * Currently only `bank:<name>` is recognised and converted to a
+ * MeiliSearch filter. The returned `query` has these operators removed.
+ */
+export function parseSearchInput(input: string): ParsedSearch {
+  let query = input
+  const filters: string[] = []
+
+  const bankRegex = /bank:("[^"]+"|\S+)/i
+  const match = input.match(bankRegex)
+  if (match) {
+    const value = match[1].replace(/^"|"$/g, "")
+    filters.push(`bank = "${value}"`)
+    query = query.replace(match[0], "").trim()
+  }
+
+  return { query: query.trim(), filters }
+}


### PR DESCRIPTION
## Summary
- parse gmail-style `bank:` operator in UI
- update MeiliSearch utility to accept filter strings
- filter results based on parsed bank name
- highlight only the non-filter search terms in results and viewer

## Testing
- `pnpm lint` *(fails: unable to download dependencies)*
- `npx tsc -p ui/tsconfig.json --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684cd02998e4832aaead04677887313d