### PR TITLE
Add multi-bank filtering

### DIFF
--- a/bankfees/ui/package.json
+++ b/bankfees/ui/package.json
@@ -11,6 +11,8 @@
   "dependencies": {
     "@radix-ui/react-collapsible": "^1.1.11",
     "@radix-ui/react-scroll-area": "^1.2.9",
+    "@radix-ui/react-checkbox": "^1.0.6",
+    "@radix-ui/react-popover": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/bankfees/ui/src/components/ui/checkbox.tsx
+++ b/bankfees/ui/src/components/ui/checkbox.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { Check } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded border border-input shadow data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      "focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator className="flex items-center justify-center text-current">
+      <Check className="h-3.5 w-3.5" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+))
+Checkbox.displayName = CheckboxPrimitive.Root.displayName
+
+export { Checkbox }

--- a/bankfees/ui/src/components/ui/popover.tsx
+++ b/bankfees/ui/src/components/ui/popover.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import * as React from "react"
+import * as PopoverPrimitive from "@radix-ui/react-popover"
+
+import { cn } from "@/lib/utils"
+
+const Popover = PopoverPrimitive.Root
+
+const PopoverTrigger = PopoverPrimitive.Trigger
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2",
+        "data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+))
+PopoverContent.displayName = PopoverPrimitive.Content.displayName
+
+export { Popover, PopoverTrigger, PopoverContent }

--- a/bankfees/ui/src/lib/utils.ts
+++ b/bankfees/ui/src/lib/utils.ts
@@ -19,12 +19,14 @@ export function parseSearchInput(input: string): ParsedSearch {
   let query = input
   const filters: string[] = []
 
-  const bankRegex = /bank:("[^"]+"|\S+)/i
-  const match = input.match(bankRegex)
-  if (match) {
-    const value = match[1].replace(/^"|"$/g, "")
-    filters.push(`bank = "${value}"`)
-    query = query.replace(match[0], "").trim()
+  const bankRegex = /bank:("[^"]+"|\S+)/gi
+  const bankMatches = [...input.matchAll(bankRegex)]
+
+  if (bankMatches.length > 0) {
+    const banks = bankMatches.map((m) => m[1].replace(/^"|"$/g, ""))
+    const filter = banks.map((b) => `bank = "${b}"`).join(" OR ")
+    filters.push(filter)
+    query = query.replace(bankRegex, "").replace(/\s+/g, " ")
   }
 
   return { query: query.trim(), filters }


### PR DESCRIPTION
## Summary
- support multiple `bank:` filters in `parseSearchInput`
- add Popover and Checkbox components
- allow selecting multiple banks via filter popover in the search UI
- update package.json dependencies

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cd46ad388832aba182def05584049