### PR TITLE
Add multi-bank filter UI sync

### DIFF
--- a/bankfees/ui/package.json
+++ b/bankfees/ui/package.json
@@ -11,6 +11,8 @@
   "dependencies": {
     "@radix-ui/react-collapsible": "^1.1.11",
     "@radix-ui/react-scroll-area": "^1.2.9",
+    "@radix-ui/react-checkbox": "^1.0.6",
+    "@radix-ui/react-popover": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/bankfees/ui/src/components/search-interface.tsx
+++ b/bankfees/ui/src/components/search-interface.tsx
@@ -6,14 +6,21 @@ import { PdfViewer } from "@/components/pdf-viewer";
 import { SearchResults } from "@/components/search-results";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { useSearchResults } from "@/hooks/use-search-results";
 import { parseSearchInput } from "@/lib/utils";
-import { Search } from "lucide-react";
+import { Filter, Search } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 
 export function SearchInterface() {
   const [searchQuery, setSearchQuery] = useState("");
+  const [selectedBanks, setSelectedBanks] = useState<string[]>([]);
   const [selectedResult, setSelectedResult] = useState<{
     bankName: string;
     documentUrl: string;
@@ -23,6 +30,8 @@ export function SearchInterface() {
 
   const { results, isLoading, error, performSearch } = useSearchResults();
   const searchParams = useSearchParams();
+
+  const allBanks = ["alpha", "attica", "eurobank", "nbg", "piraeus"];
 
   useEffect(() => {
     // Check if there's a document parameter in the URL
@@ -37,11 +46,43 @@ export function SearchInterface() {
     }
   }, [searchParams]);
 
+  const extractBanks = (input: string) => {
+    const bankRegex = /bank:("[^"]+"|\S+)/gi;
+    return [...input.matchAll(bankRegex)].map((m) =>
+      m[1].replace(/^"|"$/g, ""),
+    );
+  };
+
+  const maybePerformSearch = (value: string) => {
+    const { query } = parseSearchInput(value);
+    if (query.trim().length === 0) {
+      performSearch("");
+    } else if (query.trim().length >= 2) {
+      performSearch(value);
+    }
+  };
+
+  const toggleBankSelection = (bank: string) => {
+    setSelectedBanks((prev) => {
+      const newBanks = prev.includes(bank)
+        ? prev.filter((b) => b !== bank)
+        : [...prev, bank];
+
+      const baseQuery = searchQuery.replace(/bank:("[^"]+"|\S+)/gi, "").trim();
+      const newQuery = `${baseQuery} ${newBanks
+        .map((b) => `bank:${b}`)
+        .join(" ")}`.trim();
+
+      setSearchQuery(newQuery);
+      maybePerformSearch(newQuery);
+
+      return newBanks;
+    });
+  };
+
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
-    if (searchQuery.trim()) {
-      performSearch(searchQuery);
-    }
+    maybePerformSearch(searchQuery);
   };
 
   const { query: highlightQuery } = parseSearchInput(searchQuery);
@@ -49,7 +90,7 @@ export function SearchInterface() {
   return (
     <div className="grid grid-cols-1 lg:grid-cols-[1fr_1.5fr] gap-6">
       <div className="flex flex-col gap-6">
-        <form onSubmit={handleSearch} className="flex gap-2">
+        <form onSubmit={handleSearch} className="flex gap-2 items-start">
           <div className="relative flex-1">
             <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4" />
             <Input
@@ -57,17 +98,38 @@ export function SearchInterface() {
               placeholder="Search for fees (e.g., overdraft, wire transfer, ATM)"
               value={searchQuery}
               onChange={(e) => {
-                setSearchQuery(e.target.value);
-                const newSearchQuery = e.target.value.trim();
-                if (newSearchQuery.length === 0) {
-                  performSearch(""); // Clear results on empty input
-                } else if (newSearchQuery.length >= 2) {
-                  performSearch(newSearchQuery); // Perform search on input change
-                }
+                const value = e.target.value;
+                setSearchQuery(value);
+                setSelectedBanks(extractBanks(value));
+                maybePerformSearch(value);
               }}
               className="pl-10"
             />
           </div>
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button type="button" variant="outline" className="shrink-0">
+                <Filter className="h-4 w-4" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-40" align="start">
+              <div className="flex flex-col gap-2">
+                {allBanks.map((bank) => (
+                  <label
+                    key={bank}
+                    className="flex items-center gap-2 text-sm capitalize"
+                  >
+                    <Checkbox
+                      checked={selectedBanks.includes(bank)}
+                      onCheckedChange={() => toggleBankSelection(bank)}
+                      id={`bank-${bank}`}
+                    />
+                    {bank}
+                  </label>
+                ))}
+              </div>
+            </PopoverContent>
+          </Popover>
           <Button type="submit">Αναζήτηση</Button>
         </form>
 
@@ -95,7 +157,7 @@ export function SearchInterface() {
           <PdfViewer
             documentUrl={selectedResult.documentUrl.replace(
               "/Users/iwa/ekpizo/bankfees/data/",
-              "/api/file/"
+              "/api/file/",
             )}
             pageNumber={selectedResult.pageNumber}
             searchTerm={highlightQuery}
@@ -105,7 +167,9 @@ export function SearchInterface() {
         ) : (
           <div className="flex flex-col items-center justify-center h-full text-slate-400">
             <Search className="h-12 w-12 mb-4" />
-            <p className="text-lg">Search and select a result to view the PDF</p>
+            <p className="text-lg">
+              Search and select a result to view the PDF
+            </p>
           </div>
         )}
       </div>

--- a/bankfees/ui/src/components/ui/checkbox.tsx
+++ b/bankfees/ui/src/components/ui/checkbox.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { Check } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded border border-input shadow data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      "focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator className="flex items-center justify-center text-current">
+      <Check className="h-3.5 w-3.5" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+))
+Checkbox.displayName = CheckboxPrimitive.Root.displayName
+
+export { Checkbox }

--- a/bankfees/ui/src/components/ui/popover.tsx
+++ b/bankfees/ui/src/components/ui/popover.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import * as React from "react"
+import * as PopoverPrimitive from "@radix-ui/react-popover"
+
+import { cn } from "@/lib/utils"
+
+const Popover = PopoverPrimitive.Root
+
+const PopoverTrigger = PopoverPrimitive.Trigger
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2",
+        "data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+))
+PopoverContent.displayName = PopoverPrimitive.Content.displayName
+
+export { Popover, PopoverTrigger, PopoverContent }

--- a/bankfees/ui/src/lib/utils.ts
+++ b/bankfees/ui/src/lib/utils.ts
@@ -19,12 +19,14 @@ export function parseSearchInput(input: string): ParsedSearch {
   let query = input
   const filters: string[] = []
 
-  const bankRegex = /bank:("[^"]+"|\S+)/i
-  const match = input.match(bankRegex)
-  if (match) {
-    const value = match[1].replace(/^"|"$/g, "")
-    filters.push(`bank = "${value}"`)
-    query = query.replace(match[0], "").trim()
+  const bankRegex = /bank:("[^"]+"|\S+)/gi
+  const bankMatches = [...input.matchAll(bankRegex)]
+
+  if (bankMatches.length > 0) {
+    const banks = bankMatches.map((m) => m[1].replace(/^"|"$/g, ""))
+    const filter = banks.map((b) => `bank = "${b}"`).join(" OR ")
+    filters.push(filter)
+    query = query.replace(bankRegex, "").replace(/\s+/g, " ")
   }
 
   return { query: query.trim(), filters }


### PR DESCRIPTION
## Summary
- update filter controls to inject `bank:` operators into the search box
- sync selected banks with typed operators in the search field
- clear results when there is no textual query

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cd46ad388832aba182def05584049