### PR TITLE
Add SQLite bundle support and DB file serving

### DIFF
--- a/listobank/README.md
+++ b/listobank/README.md
@@ -87,7 +87,15 @@ python pdf_retriever.py
 python doc_classification.py
 ```
 
-4. **Index for Search**: Add documents to MeiliSearch index
+4. **Build SQLite Database**: Bundle PDFs and their analyses
+```bash
+python pdfs_to_sqlite.py --root-dir data_new --db-path documents.sqlite
+```
+
+Copy the resulting `documents.sqlite` into the `ui` folder so the
+Next.js application can serve PDFs directly from the database.
+
+5. **Index for Search**: Add documents to MeiliSearch index
 ```bash
 python pdfs_to_meili.py
 ```

--- a/listobank/pdfs_to_meili.py
+++ b/listobank/pdfs_to_meili.py
@@ -89,7 +89,7 @@ def index_pdfs(meili: Client, root_dir: Path, index_name: str, batch_size: int =
             id=doc_id,
             entity=entity_name,
             filename=pdf_file.name,
-            path=str(pdf_file),
+            path=str(pdf_file.relative_to(root_dir)),
             page=page_idx+1,
             content=content,
         )

--- a/listobank/pdfs_to_sqlite.py
+++ b/listobank/pdfs_to_sqlite.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Create a SQLite database containing all PDF files and their analysis JSON.
+
+This script walks a directory tree, stores every PDF file as a BLOB and, if
+available, the corresponding ``.analysis.json`` file as text. The resulting
+SQLite database can then be bundled with the web application for offline use.
+"""
+
+import argparse
+import sqlite3
+from pathlib import Path
+from typing import Iterable
+
+from tqdm.auto import tqdm
+
+
+def iter_pdfs(root: Path) -> Iterable[Path]:
+    """Yield all PDF files under ``root``."""
+    return root.glob("**/*.pdf")
+
+
+def store_documents(db_path: Path, pdf_files: Iterable[Path], root: Path) -> None:
+    """Insert PDFs and optional analyses into the SQLite database."""
+    with sqlite3.connect(str(db_path)) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS documents (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                path TEXT UNIQUE,
+                pdf BLOB,
+                analysis TEXT
+            )
+            """
+        )
+        conn.commit()
+
+        for pdf_file in tqdm(pdf_files, desc="Storing PDFs", unit="file"):
+            rel_path = pdf_file.relative_to(root)
+            pdf_blob = pdf_file.read_bytes()
+            analysis_file = pdf_file.with_suffix(".analysis.json")
+            analysis_text = (
+                analysis_file.read_text(encoding="utf-8") if analysis_file.is_file() else None
+            )
+            cur.execute(
+                "INSERT OR REPLACE INTO documents(path, pdf, analysis) VALUES(?, ?, ?)",
+                (str(rel_path), pdf_blob, analysis_text),
+            )
+        conn.commit()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Bundle PDFs and analyses into a SQLite database")
+    parser.add_argument(
+        "--root-dir",
+        type=Path,
+        default=Path.cwd(),
+        help="Root directory to search for PDF files (default: current directory)",
+    )
+    parser.add_argument(
+        "--db-path",
+        type=Path,
+        default=Path("documents.sqlite"),
+        help="Path to output SQLite database file (default: ./documents.sqlite)",
+    )
+    args = parser.parse_args()
+
+    pdf_files = iter_pdfs(args.root_dir)
+    store_documents(args.db_path, pdf_files, args.root_dir)
+    print(f"Created database {args.db_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/listobank/ui/package.json
+++ b/listobank/ui/package.json
@@ -21,6 +21,7 @@
     "lucide-react": "^0.515.0",
     "meilisearch": "^0.51.0",
     "mime-types": "^3.0.1",
+    "better-sqlite3": "^9.0.0",
     "next": "15.3.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/listobank/ui/src/app/api/file/[...path]/route.ts
+++ b/listobank/ui/src/app/api/file/[...path]/route.ts
@@ -1,49 +1,37 @@
-import { promises as fs } from 'fs';
 import path from 'path';
 import { lookup } from 'mime-types';
 import { NextResponse } from 'next/server';
+import Database from 'better-sqlite3';
 
 // App Router route handler: /app/api/files/[...path]/route.js
-export async function GET(request: Request, { params }: Promise<{
-  params: { path?: string[] };
-}>) {
-  console.log("Hello")
-  const pathSegments = (await params).path || [];
-  const dataDir = path.join(process.cwd(), '..', 'data');
-
-  // Construct the requested file's relative path
+export async function GET(request: Request, { params }: { params: { path?: string[] } }) {
+  const pathSegments = params.path || [];
   const relativePath = Array.isArray(pathSegments) ? pathSegments.join(path.sep) : '';
-  const filePath = path.join(dataDir, relativePath);
 
-  console.log('Requested file path:', filePath);
-  console.log('Data directory:', dataDir);  
-  console.log('Relative path:', relativePath);
-
-  // Prevent path traversal: ensure filePath is inside dataDir
-  if (!filePath.startsWith(dataDir)) {
+  if (relativePath.includes('..')) {
     return NextResponse.json({ error: 'Invalid file path' }, { status: 400 });
   }
 
+  const dbPath = path.join(process.cwd(), '..', 'documents.sqlite');
+
   try {
-    // Read the file as a Buffer
-    const fileBuffer = await fs.readFile(filePath);
+    const db = new Database(dbPath, { readonly: true });
+    const row = db.prepare('SELECT pdf FROM documents WHERE path = ?').get(relativePath);
+    db.close();
 
-    // Convert Node Buffer to Uint8Array for Response compatibility
-    const fileArray = new Uint8Array(fileBuffer);
+    if (!row) {
+      return NextResponse.json({ error: 'File not found' }, { status: 404 });
+    }
 
-    // Determine MIME type based on file extension
-    const mimeType = lookup(path.extname(filePath)) || 'application/octet-stream';
+    const fileBuffer: Buffer = row.pdf;
+    const mimeType = lookup(path.extname(relativePath)) || 'application/pdf';
 
-    // Return file in response
-    return new Response(fileArray, {
+    return new Response(fileBuffer, {
       status: 200,
       headers: { 'Content-Type': mimeType },
     });
-  } catch (err: any) {
-    if (err.code === 'ENOENT') {
-      return NextResponse.json({ error: 'File not found' }, { status: 404 });
-    }
-    console.error('File read error:', err);
+  } catch (err) {
+    console.error('Database error:', err);
     return NextResponse.json({ error: 'Server error' }, { status: 500 });
   }
 }

--- a/listobank/ui/src/components/pdf-library.tsx
+++ b/listobank/ui/src/components/pdf-library.tsx
@@ -187,7 +187,10 @@ function DocumentCard({ document }: { document: Document }) {
               Search within document
             </Link>
             <a
-              href={document.path}
+              href={`/api/file/${document.path
+                .split('/')
+                .map(encodeURIComponent)
+                .join('/')}`}
               target="_blank"
               rel="noopener noreferrer"
               className="flex items-center gap-1 text-xs text-blue-600 hover:text-blue-800"

--- a/listobank/ui/src/components/search-interface.tsx
+++ b/listobank/ui/src/components/search-interface.tsx
@@ -155,10 +155,10 @@ export function SearchInterface() {
       <div className="bg-white rounded-lg shadow-sm border h-[calc(100vh-12rem)] min-h-[500px]">
         {selectedResult ? (
           <PdfViewer
-            documentUrl={selectedResult.documentUrl.replace(
-              "/Users/iwa/ekpizo/bankfees/data/",
-              "/api/file/",
-            )}
+            documentUrl={`/api/file/${selectedResult.documentUrl
+              .split('/')
+              .map(encodeURIComponent)
+              .join('/')}`}
             pageNumber={selectedResult.pageNumber}
             searchTerm={highlightQuery}
             highlight={selectedResult.highlight}


### PR DESCRIPTION
## Summary
- improve `pdfs_to_sqlite.py` with context manager and streaming
- store relative paths in `pdfs_to_meili.py`
- update documentation about copying `documents.sqlite`
- serve PDF files from SQLite in Next.js API route
- adjust UI components to fetch documents via the new route
- declare `better-sqlite3` dependency

## Testing
- `python -m py_compile listobank/pdfs_to_sqlite.py listobank/pdfs_to_meili.py`
- `pnpm lint` *(fails: Proxy response (403) when installing pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_684f71caacb8832ab0bcd0218427d67e